### PR TITLE
Bring http-client and time deps up-to-date.

### DIFF
--- a/src/Twilio/Internal/Parser.hs
+++ b/src/Twilio/Internal/Parser.hs
@@ -10,7 +10,6 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Time.Clock
 import Data.Time.Format
-import System.Locale
 
 (<&>) :: Functor f => f a -> (a -> b) -> f b
 (<&>) = flip fmap
@@ -32,13 +31,13 @@ filterEmpty t = Just t
 
 parseDate :: (Monad m, MonadPlus m) => Text -> m UTCTime
 parseDate s =
-  case parseTime defaultTimeLocale "%F" (T.unpack s) of
+  case parseTimeM True defaultTimeLocale "%F" (T.unpack s) of
     Just date -> return date
     Nothing   -> mzero
 
 parseDateTime :: (Monad m, MonadPlus m) => Text -> m UTCTime
 parseDateTime s =
-  case parseTime defaultTimeLocale "%a, %d %b %Y %T %z" (T.unpack s) of
+  case parseTimeM True defaultTimeLocale "%a, %d %b %Y %T %z" (T.unpack s) of
     Just dateTime -> return dateTime
     Nothing       -> mzero
 

--- a/twilio.cabal
+++ b/twilio.cabal
@@ -1,5 +1,5 @@
 name:                twilio
-version:             0.1.1.0
+version:             0.1.2.0
 synopsis:            Twilio REST API library for Haskell
 description:         This package exports bindings to Twilio's REST API (<https://www.twilio.com/docs/api/rest>). While we would like to have a complete binding to Twilio's REST API, this package is being developed on demand. If you need something that has not been implemented yet, please send a pull request or file an issue on GitHub (<https://github.com/markandrus/twilio-haskell>).
 homepage:            https://github.com/markandrus/twilio-haskell
@@ -68,14 +68,14 @@ library
                        errors ==1.4.*,
                        exceptions ==0.*,
                        free ==4.*,
-                       http-client ==0.2.*,
+                       http-client ==0.4.*,
                        http-client-tls ==0.2.*,
                        http-types ==0.*,
                        mtl ==2.*,
                        network-uri >=2.6,
                        old-locale ==1.0.*,
                        text ==1.*,
-                       time ==1.4.*,
+                       time ==1.5.*,
                        transformers ==0.4.*,
                        unordered-containers ==0.2.*
 


### PR DESCRIPTION
The new http-client package causes no API issues.

The new time package has a deprecation notice on parseTime in favor
of parseTimeM. Docs for this are here: https://hackage.haskell.org/package/time-1.5.0.1/docs/Data-Time-Format.html

It also provides its own defaultTimeLocale instance, replacing the
previous one imported from System.Locale. Though tests still pass, their
implementation is at least slightly different. Because of this we bump
the major version number of twilio-haskell in this commit.
