### PR TITLE
Modified the README.md to include a second example

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ Documentation soon to be available on Hackage. For now, see [markandrus.github.i
 
 For TwiML, see [twiml-haskell](http://github.com/markandrus/twiml-haskell).
 
-Example
+Example 1 - using environment variables
 -------
 
-You can create a REST API client and fetch the calls resources as follows
+You can create a REST API client, fetch the calls, or send a message as follows:
 
 ```hs
 {-#LANGUAGE OverloadedStrings #-}
@@ -38,9 +38,51 @@ main = runTwilio' (getEnv "ACCOUNT_SID")
   liftIO $ print calls
 
   -- Send a Message.
-  let body = PostMessage "+14158059869" "+14158059869" "Oh, hai"
+  let receivingPhone = "+14158059869"
+  let sendingPhone = "+14158059869"
+  let body = PostMessage receivingPhone sendingPhone "Oh, hai"
   message <- post body
   liftIO $ print message
+```
+
+Example 2 - using SID and secret embedded in the code
+-------
+
+You can create a REST API client and send a message as follows:
+
+```hs
+{-#LANGUAGE OverloadedStrings #-}
+
+module Main where
+import Twilio.Types.SID
+import Control.Monad.IO.Class (liftIO)
+import Twilio
+import Twilio.Messages
+import qualified Data.Text as T
+
+parseCredentials :: T.Text -> T.Text -> Maybe Credentials
+parseCredentials accountSID authToken =
+    case parseAuthToken authToken of
+        Just authToken ->
+            (case parseSID accountSID of
+                Just accountSID ->
+                    Just (accountSID, authToken)
+                Nothing -> Nothing)
+        Nothing -> Nothing
+
+main :: IO ()
+main =
+    let accountSID = "youraccountSID"
+        authToken = "yourauthToken"
+    in case parseCredentials accountSID authToken of
+        Just credentialsPassed ->
+            runTwilio ( credentialsPassed ) $ do
+                let receivingPhone = "+14158059869"
+                let sendingPhone = "+14158059869"
+                let body = PostMessage receivingPhone sendingPhone "Oh, hai"
+                message <- post body
+                liftIO $ print message
+        Nothing -> print "Something bad happened, you have poorly formed credentials."
 ```
 
 Contributing

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ main = runTwilio' (getEnv "ACCOUNT_SID")
   liftIO $ print calls
 
   -- Send a Message.
-  let receivingPhone = "+14158059869"
-  let sendingPhone = "+14158059869"
+  let fromPhone = "+14158059869"
+  let toPhone = "+14158059869"
   let body = PostMessage receivingPhone sendingPhone "Oh, hai"
   message <- post body
   liftIO $ print message
@@ -54,35 +54,36 @@ You can create a REST API client and send a message as follows:
 {-#LANGUAGE OverloadedStrings #-}
 
 module Main where
-import Twilio.Types.SID
+
 import Control.Monad.IO.Class (liftIO)
+import Data.Text (Text)
 import Twilio
 import Twilio.Messages
-import qualified Data.Text as T
+import Twilio.Types.SID
 
-parseCredentials :: T.Text -> T.Text -> Maybe Credentials
+parseCredentials :: Text -> Text -> Maybe Credentials
 parseCredentials accountSID authToken =
-    case parseAuthToken authToken of
-        Just authToken ->
-            (case parseSID accountSID of
-                Just accountSID ->
-                    Just (accountSID, authToken)
-                Nothing -> Nothing)
-        Nothing -> Nothing
+  case parseAuthToken authToken of
+    Just authToken ->
+      (case parseSID accountSID of
+        Just accountSID ->
+          Just (accountSID, authToken)
+        Nothing -> Nothing)
+    Nothing -> Nothing
 
 main :: IO ()
 main =
-    let accountSID = "youraccountSID"
-        authToken = "yourauthToken"
-    in case parseCredentials accountSID authToken of
-        Just credentialsPassed ->
-            runTwilio ( credentialsPassed ) $ do
-                let receivingPhone = "+14158059869"
-                let sendingPhone = "+14158059869"
-                let body = PostMessage receivingPhone sendingPhone "Oh, hai"
-                message <- post body
-                liftIO $ print message
-        Nothing -> print "Something bad happened, you have poorly formed credentials."
+  let accountSID = "youraccountSID"
+    authToken = "yourauthToken"
+  in case parseCredentials accountSID authToken of
+    Just credentialsPassed ->
+      runTwilio ( credentialsPassed ) $ do
+        let fromPhone = "+14158059869"
+        let toPhone = "+14158059869"
+        let body = PostMessage receivingPhone sendingPhone "Oh, hai"
+        message <- post body
+        liftIO $ print message
+    Nothing -> print "Something bad happened, you have poorly formed credentials."
 ```
 
 Contributing


### PR DESCRIPTION
Modified the README.md to include a second example where the account SID and
auth token are embedded in the code rather than stored as environmental
variables. This would allow a developer to compile a self-contained executable
that could be run by end users without the need to create or understand
environment variables. Also modified both examples to define sending and
receiving phone number bindings to make it easier for the developer to
read/configure.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/markandrus/twilio-haskell/40)

<!-- Reviewable:end -->
