### PR TITLE
Add DELETE Recording.

### DIFF
--- a/src/Twilio/Recording.hs
+++ b/src/Twilio/Recording.hs
@@ -12,6 +12,7 @@
 module Twilio.Recording
   ( -- * Resource
     Recording(..)
+  , Twilio.Recording.delete
   , Twilio.Recording.get
   ) where
 

--- a/src/Twilio/Recording.hs
+++ b/src/Twilio/Recording.hs
@@ -63,3 +63,10 @@ instance Get1 RecordingSID Recording where
 -- | Get a 'Recording' by 'RecordingSID'.
 get :: MonadThrow m => RecordingSID -> TwilioT m Recording
 get = Resource.get
+
+instance Delete1 RecordingSID where
+  delete1 (getSID -> sid) = request parseJSONFromResponse =<< makeTwilioDELETERequest
+    ("/Recordings/" <> sid <> ".json")
+
+delete :: MonadThrow m => RecordingSID -> TwilioT m ()
+delete = Resource.delete


### PR DESCRIPTION
This hopefully address #47.

No tests have been implemented for this PR. The reason is that, in order to test deleting a recording, we'd have to be able to create a recording, and that is not currently available per the [api](https://www.twilio.com/docs/api/voice/recording#http-post) docs.