### PR TITLE
Make phone number in test suite configurable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,21 @@ main = runTwilio' (getEnv "ACCOUNT_SID")
   liftIO $ print message
 ```
 
+Testing
+------------
+Currently, our test suite makes calls to Twilio's API. This means that you will
+be unable to test without a Twilio account.
+
+To test on your local machine, set the environment variables `ACCOUNT_SID`,
+`AUTH_TOKEN`, and `TEST_PHONE`. Twilio provides both test credentials and
+non-test credentials. Make sure to use your **non-test credentials**.
+Furthermore, the phone number must be able to make / receive calls, and be SMS
+enabled.
+
+The easiest way to provision a compatible phone number is to use the [Twilio
+Website](https://www.twilio.com/console/phone-numbers/search) to buy a number,
+with Voice / SMS / MMS capabilities.
+
 Contributing
 ------------
 

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -6,7 +6,8 @@ module Main where
 
 import Control.Monad.IO.Class
 import Data.Monoid
-import Data.Text (Text, unpack)
+import Data.Maybe (fromMaybe)
+import Data.Text (Text, unpack, pack)
 import Network.URI
 import System.Environment
 import Twilio
@@ -145,8 +146,9 @@ testPOSTCalls :: Twilio Call
 testPOSTCalls = do
   liftIO $ putStrLn "POST /Calls"
   let Just url = parseAbsoluteURI "https://demo.twilio.com/welcome/voice/"
+  testPhone <- liftIO $ getTestPhoneWithDefault "+14157671887"
   (call :: Call) <- Twilio.Internal.Resource.post
-    ("+14158059869" :: Text) ("+14158059869" :: Text) url
+    (testPhone :: Text) (testPhone :: Text) url
   liftIO $ print call
   return call
 
@@ -178,7 +180,8 @@ testGETMessages = do
 testPOSTMessages :: Twilio Message
 testPOSTMessages = do
   liftIO $ putStrLn "POST /Messages"
-  let body = PostMessage "+14157671887" "+14158059869" "Hello"
+  testPhone <- liftIO $ getTestPhoneWithDefault "+14157671887"
+  let body = PostMessage testPhone testPhone "Hello"
   message <- Messages.post body
   liftIO $ print message
   return message
@@ -249,3 +252,7 @@ testPOSTTokens = do
   token <- Tokens.post Nothing
   liftIO $ print token
   return token
+
+getTestPhoneWithDefault defaultPhone = do
+  maybeTestPhone <- lookupEnv "TEST_PHONE"
+  return (pack $ fromMaybe defaultPhone maybeTestPhone)


### PR DESCRIPTION
@markandrus I have a gut feeling that there is likely a better way to make the test phone number configurable. That being said, the below compiles and works.

I'd be glad to iterate on this until we get something up to par in terms of quality.