### PR TITLE
Fix Travis CI failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+# NOTE(mroberts): https://github.com/travis-ci/travis-ci/issues/4704
+filter_secrets: false
+
 sudo: false
 
 language: generic
@@ -84,6 +87,7 @@ script:
      cabal)
        cabal --version
        travis_retry cabal update
+       sed -i 's/^jobs:/-- jobs:/' ${HOME}/.cabal/config
        cabal install --dependencies-only
        cabal configure --enable-tests --enable-benchmarks -v2
        cabal build

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -181,7 +181,7 @@ testPOSTMessages :: Twilio Message
 testPOSTMessages = do
   liftIO $ putStrLn "POST /Messages"
   testPhone <- liftIO $ getTestPhoneWithDefault "+14157671887"
-  let body = PostMessage testPhone testPhone "Hello"
+  let body = PostMessage "+12027621401" testPhone "Hello"
   message <- Messages.post body
   liftIO $ print message
   return message


### PR DESCRIPTION
I saw some broken log output that looked familiar to me, so this PR disables
`filter_secrets` (we do our best not to leak these, even without Travis's help,
so we'll just have to continue ensuring we don't `echo` any secrets). We also
have some timeouts for normal `cabal build`s, so I added the workaround from
[here](https://github.com/hvr/multi-ghc-travis#known-issues).
    
Also, in our test, we POST to /Messages using the same To and From number. I
guess this doesn't work anymore (I thought it used to), so I set the To number
to something else.