### PR TITLE
Support template-haskell >=2.12, relax upper bound on free

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,22 @@ matrix:
       compiler: ": #stack 8.0.1"
       addons: {apt: {packages: [libgmp-dev]}}
 
+    - env: BUILD=stack ARGS="--resolver lts-8"
+      compiler: ": #stack 8.0.2"
+      addons: {apt: {packages: [libgmp-dev]}}
+
+    - env: BUILD=stack ARGS="--resolver lts-9"
+      compiler: ": #stack 8.0.2"
+      addons: {apt: {packages: [libgmp-dev]}}
+
+    - env: BUILD=stack ARGS="--resolver lts-10"
+      compiler: ": #stack 8.2.2"
+      addons: {apt: {packages: [libgmp-dev]}}
+
+    - env: BUILD=stack ARGS="--resolver lts-11"
+      compiler: ": #stack 8.2.2"
+      addons: {apt: {packages: [libgmp-dev]}}
+
 before_install:
  - unset CC
  - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$HOME/.local/bin:$PATH

--- a/src/Twilio/Types/SID/TH.hs
+++ b/src/Twilio/Types/SID/TH.hs
@@ -23,6 +23,9 @@ import Language.Haskell.TH
 #else
   ( Strict(..)
 #endif
+#if MIN_VERSION_template_haskell(2,12,0)
+  , DerivClause(..)
+#endif
   , Body(..)
   , Clause(..)
   , Con(..)
@@ -98,7 +101,11 @@ createSID a b resource = pure
           )
         ]
       )
+#if MIN_VERSION_template_haskell(2,12,0)
+      [DerivClause Nothing derivedClasses]
+#else
       derivedClasses
+#endif
 
     sidType = AppT
       (AppT (ConT $ mkName "SID")

--- a/twilio.cabal
+++ b/twilio.cabal
@@ -92,7 +92,7 @@ library
                        deepseq >=1,
                        errors >=1,
                        exceptions ==0.*,
-                       free ==4.*,
+                       free ==4.* || ==5.*,
                        hashable >=1,
                        http-client >=0.4,
                        http-client-tls >=0.2,


### PR DESCRIPTION
These two changes allow `twilio` package to be built with LTS 10.* & 11.*, i.e. GHC 8.2.2.