### PR TITLE
Minor updates - and remove body printing

### DIFF
--- a/src/Twilio/APIKey.hs
+++ b/src/Twilio/APIKey.hs
@@ -20,7 +20,6 @@ module Twilio.APIKey
 import Control.Monad
 import Control.Monad.Catch
 import Data.Aeson
-import Data.Monoid
 import Data.Text (Text)
 import Data.Time.Clock
 

--- a/src/Twilio/Account.hs
+++ b/src/Twilio/Account.hs
@@ -26,7 +26,6 @@ module Twilio.Account
 import Control.Monad
 import Control.Monad.Catch
 import Data.Aeson
-import Data.Monoid
 import Data.Text (Text)
 import Data.Time.Clock
 import Network.URI

--- a/src/Twilio/Address.hs
+++ b/src/Twilio/Address.hs
@@ -20,7 +20,6 @@ import Control.Error.Safe
 import Control.Monad
 import Control.Monad.Catch
 import Data.Aeson
-import Data.Monoid
 import Data.Text (Text)
 
 import Control.Monad.Twilio

--- a/src/Twilio/Application.hs
+++ b/src/Twilio/Application.hs
@@ -20,7 +20,6 @@ module Twilio.Application
 import Control.Monad
 import Control.Monad.Catch
 import Data.Aeson
-import Data.Monoid
 import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Time.Clock

--- a/src/Twilio/AuthorizedConnectApp.hs
+++ b/src/Twilio/AuthorizedConnectApp.hs
@@ -19,7 +19,6 @@ module Twilio.AuthorizedConnectApp
 import Control.Monad
 import Control.Monad.Catch
 import Data.Aeson
-import Data.Monoid
 import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Time.Clock

--- a/src/Twilio/AvailablePhoneNumbers.hs
+++ b/src/Twilio/AvailablePhoneNumbers.hs
@@ -18,7 +18,6 @@ module Twilio.AvailablePhoneNumbers
 import Control.Applicative
 import Control.Monad.Catch
 import Data.Aeson
-import Data.Monoid
 import qualified Data.Text as T
 
 import Control.Monad.Twilio

--- a/src/Twilio/Call.hs
+++ b/src/Twilio/Call.hs
@@ -24,7 +24,6 @@ import Control.Error.Safe
 import Control.Monad
 import Control.Monad.Catch
 import Data.Aeson
-import Data.Monoid
 import Data.Text (Text)
 import Data.Time.Clock
 import Network.URI

--- a/src/Twilio/Call/Feedback.hs
+++ b/src/Twilio/Call/Feedback.hs
@@ -24,7 +24,6 @@ import Control.Monad
 import Control.Monad.Catch
 import Data.Aeson
 import Data.Data
-import Data.Monoid
 import Data.Scientific
 import Data.Time.Clock
 import GHC.Generics

--- a/src/Twilio/Conference.hs
+++ b/src/Twilio/Conference.hs
@@ -21,7 +21,6 @@ module Twilio.Conference
 import Control.Monad
 import Data.Aeson
 import Data.Data
-import Data.Monoid
 import Data.Text (Text)
 import Data.Time.Clock
 import GHC.Generics

--- a/src/Twilio/Conference/Participant.hs
+++ b/src/Twilio/Conference/Participant.hs
@@ -19,7 +19,6 @@ module Twilio.Conference.Participant
 import Control.Monad
 import Data.Aeson
 import Data.Data
-import Data.Monoid
 import Data.Time.Clock
 import GHC.Generics
 import Network.URI

--- a/src/Twilio/Conference/Participants.hs
+++ b/src/Twilio/Conference/Participants.hs
@@ -20,7 +20,6 @@ import Control.Applicative
 import Data.Aeson
 import Data.Data
 import Data.Maybe
-import Data.Monoid
 import GHC.Generics
 
 import Twilio.Conference.Participant

--- a/src/Twilio/ConnectApp.hs
+++ b/src/Twilio/ConnectApp.hs
@@ -19,7 +19,6 @@ module Twilio.ConnectApp
 import Control.Monad
 import Control.Monad.Catch
 import Data.Aeson
-import Data.Monoid
 import Data.Text (Text)
 import qualified Data.Text as T
 import Network.URI

--- a/src/Twilio/IncomingPhoneNumber.hs
+++ b/src/Twilio/IncomingPhoneNumber.hs
@@ -18,7 +18,6 @@ module Twilio.IncomingPhoneNumber
 import Control.Monad
 import Control.Monad.Catch
 import Data.Aeson
-import Data.Monoid
 import Data.Text (Text)
 import Data.Time.Clock
 import Network.URI

--- a/src/Twilio/Internal/Request.hs
+++ b/src/Twilio/Internal/Request.hs
@@ -74,5 +74,5 @@ runRequest' credentials (RequestT (FreeT m)) = m >>= \case
           else do
             let body = responseBody response
             body' <- LBS.fromChunks <$> brConsume body
-            print body'
+            -- print body'
             go $ const body' <$> response

--- a/src/Twilio/Message.hs
+++ b/src/Twilio/Message.hs
@@ -21,7 +21,6 @@ module Twilio.Message
 import Control.Monad
 import Control.Monad.Catch
 import Data.Aeson
-import Data.Monoid
 import Data.Text (Text)
 import Data.Time.Clock
 import Network.URI

--- a/src/Twilio/Message/Media.hs
+++ b/src/Twilio/Message/Media.hs
@@ -20,7 +20,6 @@ module Twilio.Message.Media
 import Control.Monad
 import Data.Aeson
 import Data.Data
-import Data.Monoid
 import Data.Text (Text)
 import Data.Time.Clock
 import GHC.Generics

--- a/src/Twilio/Message/MediaList.hs
+++ b/src/Twilio/Message/MediaList.hs
@@ -21,7 +21,6 @@ import Control.Applicative
 import Data.Aeson
 import Data.Data
 import Data.Maybe
-import Data.Monoid
 import GHC.Generics
 
 import Twilio.Internal.Request

--- a/src/Twilio/OutgoingCallerID.hs
+++ b/src/Twilio/OutgoingCallerID.hs
@@ -19,7 +19,6 @@ module Twilio.OutgoingCallerID
 import Control.Monad
 import Control.Monad.Catch
 import Data.Aeson
-import Data.Monoid
 import Data.Text (Text)
 import Data.Time.Clock
 import Network.URI

--- a/src/Twilio/Queue.hs
+++ b/src/Twilio/Queue.hs
@@ -22,7 +22,6 @@ import Control.Monad
 import Control.Monad.Catch
 import Data.Aeson
 import Data.Data
-import Data.Monoid
 import Data.Text (Text)
 import Data.Time.Clock
 import GHC.Generics

--- a/src/Twilio/Queue/Member.hs
+++ b/src/Twilio/Queue/Member.hs
@@ -19,7 +19,6 @@ module Twilio.Queue.Member
 import Control.Monad
 import Data.Aeson
 import Data.Data
-import Data.Monoid
 import Data.Time.Clock
 import GHC.Generics
 import Network.URI

--- a/src/Twilio/Queue/Members.hs
+++ b/src/Twilio/Queue/Members.hs
@@ -20,7 +20,6 @@ import Control.Applicative
 import Data.Aeson
 import Data.Data
 import Data.Maybe
-import Data.Monoid
 import GHC.Generics
 
 import Twilio.Queue.Member

--- a/src/Twilio/Recording.hs
+++ b/src/Twilio/Recording.hs
@@ -20,7 +20,6 @@ import Control.Error.Safe
 import Control.Monad
 import Control.Monad.Catch
 import Data.Aeson
-import Data.Monoid
 import Data.Time.Clock
 import Network.URI
 

--- a/src/Twilio/ShortCode.hs
+++ b/src/Twilio/ShortCode.hs
@@ -18,7 +18,6 @@ module Twilio.ShortCode
 import Control.Monad
 import Control.Monad.Catch
 import Data.Aeson
-import Data.Monoid
 import Data.Text (Text)
 import Data.Time.Clock
 import Network.URI

--- a/src/Twilio/Transcription.hs
+++ b/src/Twilio/Transcription.hs
@@ -22,7 +22,6 @@ import Control.Error.Safe
 import Control.Monad
 import Control.Monad.Catch
 import Data.Aeson
-import Data.Monoid
 import Data.Text (Text)
 import Data.Time.Clock
 import Network.URI

--- a/src/Twilio/Types.hs
+++ b/src/Twilio/Types.hs
@@ -34,7 +34,6 @@ import Control.Monad
 import Control.Monad.Reader.Class
 import Data.Aeson
 import qualified Data.ByteString.Char8 as C
-import Data.Monoid
 import Data.Text (Text)
 import qualified Data.Text as T
 #if MIN_VERSION_http_client(0,5,0)

--- a/src/Twilio/Types/SID.hs
+++ b/src/Twilio/Types/SID.hs
@@ -26,7 +26,6 @@ import Data.Bits (countLeadingZeros)
 import Data.Data (Data, Typeable)
 import Data.Hashable (Hashable)
 import Data.Ix (Ix)
-import Data.Monoid ((<>))
 import Data.String (IsString(fromString))
 import Data.Text (Text)
 import qualified Data.Text as T

--- a/src/Twilio/Types/SID/TH.hs
+++ b/src/Twilio/Types/SID/TH.hs
@@ -14,7 +14,6 @@ module Twilio.Types.SID.TH
   ( createSID
   ) where
 
-import Data.Monoid ((<>))
 import Language.Haskell.TH
 #if MIN_VERSION_template_haskell(2,11,0)
   ( Bang(..)

--- a/src/Twilio/UsageTrigger.hs
+++ b/src/Twilio/UsageTrigger.hs
@@ -18,7 +18,6 @@ module Twilio.UsageTrigger
 import Control.Monad
 import Control.Monad.Catch
 import Data.Aeson
-import Data.Monoid
 import Data.Text (Text)
 import Data.Time.Clock
 import Network.URI

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-8.20
+resolver: lts-13.2
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/test/api/Test.hs
+++ b/test/api/Test.hs
@@ -5,7 +5,6 @@
 module Main where
 
 import Control.Monad.IO.Class
-import Data.Monoid
 import Data.Maybe (fromMaybe)
 import Data.Text (Text, unpack, pack)
 import Network.URI

--- a/twilio.cabal
+++ b/twilio.cabal
@@ -88,7 +88,7 @@ library
                        base ==4.*,
                        binary >=0.7,
                        bytestring ==0.10.*,
-                       containers ==0.5.*,
+                       containers >= 0.5.0 && <0.7.0,
                        deepseq >=1,
                        errors >=1,
                        exceptions ==0.*,


### PR DESCRIPTION
I updated containers to be compatible with 0.5 and 0.6, then removed the Data.Monoid imports (no longer neccesary). 

I removed the print statement in `runRequest'`, because it makes the library unusable (my programs log to stdout, so this means user information can become leaked to the logs.) I'd recommend leaving it out until you make it configurable. (Debug mode?)