### PR TITLE
 Update to support GHC 8.2.2, 8.4.4, 8.6.5 + cabal 2.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 cabal.sandbox.config
 dist
 .stack-work
+# cabal 2.0
+.ghc.environment.*
+dist-newstyle

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,18 @@ matrix:
       compiler: ": #GHC 8.0.1"
       addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.1], sources: [hvr-ghc]}}
 
+    - env: BUILD=cabal CABALVER=2.0 GHCVER=8.2.2
+      compiler: ": #GHC 8.2.2"
+      addons: {apt: {packages: [cabal-install-2.0,ghc-8.2.2], sources: [hvr-ghc]}}
+
+    - env: BUILD=cabal CABALVER=2.2 GHCVER=8.4.4
+      compiler: ": #GHC 8.4.4"
+      addons: {apt: {packages: [cabal-install-2.2,ghc-8.4.4], sources: [hvr-ghc]}}
+
+    - env: BUILD=cabal CABALVER=2.4 GHCVER=8.6.5
+      compiler: ": #GHC 8.6.5"
+      addons: {apt: {packages: [cabal-install-2.4,ghc-8.6.5], sources: [hvr-ghc]}}
+
     # NOTE(mroberts): I've borrowed this from Yesod's .travis.yml:
     #
     #     https://github.com/yesodweb/yesod/blob/master/.travis.yml
@@ -74,6 +86,14 @@ matrix:
 
     - env: BUILD=stack ARGS="--resolver lts-11"
       compiler: ": #stack 8.2.2"
+      addons: {apt: {packages: [libgmp-dev]}}
+
+    - env: BUILD=stack ARGS="--resolver lts-12"
+      compiler: ": #stack 8.4.4"
+      addons: {apt: {packages: [libgmp-dev]}}
+
+    - env: BUILD=stack ARGS="--resolver lts-13"
+      compiler: ": #stack 8.6.5"
       addons: {apt: {packages: [libgmp-dev]}}
 
 before_install:

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,1 @@
+packages: *.cabal

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,20 @@
+{ compiler ? "ghc865" }:
+
+let
+  nixpkgs = import <nixpkgs> {};
+  inherit (nixpkgs) pkgs stdenv;
+in
+# Make a new "derivation" that represents our shell
+stdenv.mkDerivation {
+  name = "twilio-haskell";
+
+  # The packages in the `buildInputs` list will be added to the PATH in our shell
+  buildInputs = [
+    pkgs.cabal-install
+    pkgs.haskell.compiler.${compiler}
+    pkgs.xz
+    pkgs.zlib
+  ];
+
+  LIBRARY_PATH = "${pkgs.xz.out}/lib:${pkgs.zlib}/lib";
+}

--- a/src/Twilio/APIKey.hs
+++ b/src/Twilio/APIKey.hs
@@ -1,3 +1,4 @@
+{-#LANGUAGE CPP #-}
 {-#LANGUAGE FlexibleInstances #-}
 {-#LANGUAGE MultiParamTypeClasses #-}
 {-#LANGUAGE OverloadedStrings #-}
@@ -20,7 +21,9 @@ module Twilio.APIKey
 import Control.Monad
 import Control.Monad.Catch
 import Data.Aeson
+#if __GLASGOW_HASKELL__ <= 802
 import Data.Monoid
+#endif
 import Data.Text (Text)
 import Data.Time.Clock
 

--- a/src/Twilio/Account.hs
+++ b/src/Twilio/Account.hs
@@ -1,3 +1,4 @@
+{-#LANGUAGE CPP #-}
 {-#LANGUAGE FlexibleInstances #-}
 {-#LANGUAGE MultiParamTypeClasses #-}
 {-#LANGUAGE OverloadedStrings #-}
@@ -26,7 +27,9 @@ module Twilio.Account
 import Control.Monad
 import Control.Monad.Catch
 import Data.Aeson
+#if __GLASGOW_HASKELL__ <= 802
 import Data.Monoid
+#endif
 import Data.Text (Text)
 import Data.Time.Clock
 import Network.URI

--- a/src/Twilio/Address.hs
+++ b/src/Twilio/Address.hs
@@ -1,3 +1,4 @@
+{-#LANGUAGE CPP #-}
 {-#LANGUAGE FlexibleInstances #-}
 {-#LANGUAGE MultiParamTypeClasses #-}
 {-#LANGUAGE OverloadedStrings #-}
@@ -20,7 +21,9 @@ import Control.Error.Safe
 import Control.Monad
 import Control.Monad.Catch
 import Data.Aeson
+#if __GLASGOW_HASKELL__ <= 802
 import Data.Monoid
+#endif
 import Data.Text (Text)
 
 import Control.Monad.Twilio

--- a/src/Twilio/Application.hs
+++ b/src/Twilio/Application.hs
@@ -1,3 +1,4 @@
+{-#LANGUAGE CPP #-}
 {-#LANGUAGE MultiParamTypeClasses #-}
 {-#LANGUAGE OverloadedStrings #-}
 -------------------------------------------------------------------------------
@@ -20,7 +21,9 @@ module Twilio.Application
 import Control.Monad
 import Control.Monad.Catch
 import Data.Aeson
+#if __GLASGOW_HASKELL__ <= 802
 import Data.Monoid
+#endif
 import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Time.Clock

--- a/src/Twilio/AuthorizedConnectApp.hs
+++ b/src/Twilio/AuthorizedConnectApp.hs
@@ -1,3 +1,4 @@
+{-#LANGUAGE CPP #-}
 {-#LANGUAGE MultiParamTypeClasses #-}
 {-#LANGUAGE OverloadedStrings #-}
 {-#LANGUAGE ViewPatterns #-}
@@ -19,7 +20,9 @@ module Twilio.AuthorizedConnectApp
 import Control.Monad
 import Control.Monad.Catch
 import Data.Aeson
+#if __GLASGOW_HASKELL__ <= 802
 import Data.Monoid
+#endif
 import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Time.Clock

--- a/src/Twilio/AvailablePhoneNumbers.hs
+++ b/src/Twilio/AvailablePhoneNumbers.hs
@@ -1,3 +1,4 @@
+{-#LANGUAGE CPP #-}
 {-#LANGUAGE MultiParamTypeClasses #-}
 {-#LANGUAGE OverloadedStrings #-}
 {-#LANGUAGE ViewPatterns #-}
@@ -18,7 +19,9 @@ module Twilio.AvailablePhoneNumbers
 import Control.Applicative
 import Control.Monad.Catch
 import Data.Aeson
+#if __GLASGOW_HASKELL__ <= 802
 import Data.Monoid
+#endif
 import qualified Data.Text as T
 
 import Control.Monad.Twilio

--- a/src/Twilio/Call.hs
+++ b/src/Twilio/Call.hs
@@ -1,3 +1,4 @@
+{-#LANGUAGE CPP #-}
 {-#LANGUAGE MultiParamTypeClasses #-}
 {-#LANGUAGE OverloadedStrings #-}
 {-#LANGUAGE ViewPatterns #-}
@@ -24,7 +25,9 @@ import Control.Error.Safe
 import Control.Monad
 import Control.Monad.Catch
 import Data.Aeson
+#if __GLASGOW_HASKELL__ <= 802
 import Data.Monoid
+#endif
 import Data.Text (Text)
 import Data.Time.Clock
 import Network.URI

--- a/src/Twilio/Call/Feedback.hs
+++ b/src/Twilio/Call/Feedback.hs
@@ -1,3 +1,4 @@
+{-#LANGUAGE CPP #-}
 {-#LANGUAGE DeriveDataTypeable #-}
 {-#LANGUAGE DeriveGeneric #-}
 {-#LANGUAGE MultiParamTypeClasses #-}
@@ -24,7 +25,9 @@ import Control.Monad
 import Control.Monad.Catch
 import Data.Aeson
 import Data.Data
+#if __GLASGOW_HASKELL__ <= 802
 import Data.Monoid
+#endif
 import Data.Scientific
 import Data.Time.Clock
 import GHC.Generics

--- a/src/Twilio/Conference.hs
+++ b/src/Twilio/Conference.hs
@@ -1,3 +1,4 @@
+{-#LANGUAGE CPP #-}
 {-#LANGUAGE DeriveDataTypeable #-}
 {-#LANGUAGE DeriveGeneric #-}
 {-#LANGUAGE MultiParamTypeClasses #-}
@@ -21,7 +22,9 @@ module Twilio.Conference
 import Control.Monad
 import Data.Aeson
 import Data.Data
+#if __GLASGOW_HASKELL__ <= 802
 import Data.Monoid
+#endif
 import Data.Text (Text)
 import Data.Time.Clock
 import GHC.Generics

--- a/src/Twilio/Conference/Participant.hs
+++ b/src/Twilio/Conference/Participant.hs
@@ -1,3 +1,4 @@
+{-#LANGUAGE CPP #-}
 {-#LANGUAGE DeriveDataTypeable #-}
 {-#LANGUAGE DeriveGeneric #-}
 {-#LANGUAGE MultiParamTypeClasses #-}
@@ -19,7 +20,9 @@ module Twilio.Conference.Participant
 import Control.Monad
 import Data.Aeson
 import Data.Data
+#if __GLASGOW_HASKELL__ <= 802
 import Data.Monoid
+#endif
 import Data.Time.Clock
 import GHC.Generics
 import Network.URI

--- a/src/Twilio/Conference/Participants.hs
+++ b/src/Twilio/Conference/Participants.hs
@@ -1,3 +1,4 @@
+{-#LANGUAGE CPP #-}
 {-#LANGUAGE DeriveDataTypeable #-}
 {-#LANGUAGE DeriveGeneric #-}
 {-#LANGUAGE MultiParamTypeClasses #-}
@@ -20,7 +21,9 @@ import Control.Applicative
 import Data.Aeson
 import Data.Data
 import Data.Maybe
+#if __GLASGOW_HASKELL__ <= 802
 import Data.Monoid
+#endif
 import GHC.Generics
 
 import Twilio.Conference.Participant

--- a/src/Twilio/ConnectApp.hs
+++ b/src/Twilio/ConnectApp.hs
@@ -1,3 +1,4 @@
+{-#LANGUAGE CPP #-}
 {-#LANGUAGE MultiParamTypeClasses #-}
 {-#LANGUAGE OverloadedStrings #-}
 {-#LANGUAGE ViewPatterns #-}
@@ -19,7 +20,9 @@ module Twilio.ConnectApp
 import Control.Monad
 import Control.Monad.Catch
 import Data.Aeson
+#if __GLASGOW_HASKELL__ <= 802
 import Data.Monoid
+#endif
 import Data.Text (Text)
 import qualified Data.Text as T
 import Network.URI

--- a/src/Twilio/IncomingPhoneNumber.hs
+++ b/src/Twilio/IncomingPhoneNumber.hs
@@ -1,3 +1,4 @@
+{-#LANGUAGE CPP #-}
 {-#LANGUAGE MultiParamTypeClasses #-}
 {-#LANGUAGE OverloadedStrings #-}
 {-#LANGUAGE ViewPatterns #-}
@@ -18,7 +19,9 @@ module Twilio.IncomingPhoneNumber
 import Control.Monad
 import Control.Monad.Catch
 import Data.Aeson
+#if __GLASGOW_HASKELL__ <= 802
 import Data.Monoid
+#endif
 import Data.Text (Text)
 import Data.Time.Clock
 import Network.URI

--- a/src/Twilio/Internal/Request.hs
+++ b/src/Twilio/Internal/Request.hs
@@ -74,5 +74,4 @@ runRequest' credentials (RequestT (FreeT m)) = m >>= \case
           else do
             let body = responseBody response
             body' <- LBS.fromChunks <$> brConsume body
-            print body'
             go $ const body' <$> response

--- a/src/Twilio/Message.hs
+++ b/src/Twilio/Message.hs
@@ -1,3 +1,4 @@
+{-#LANGUAGE CPP #-}
 {-#LANGUAGE MultiParamTypeClasses #-}
 {-#LANGUAGE OverloadedStrings #-}
 {-#LANGUAGE ViewPatterns #-}
@@ -21,7 +22,9 @@ module Twilio.Message
 import Control.Monad
 import Control.Monad.Catch
 import Data.Aeson
+#if __GLASGOW_HASKELL__ <= 802
 import Data.Monoid
+#endif
 import Data.Text (Text)
 import Data.Time.Clock
 import Network.URI

--- a/src/Twilio/Message/Media.hs
+++ b/src/Twilio/Message/Media.hs
@@ -1,3 +1,4 @@
+{-#LANGUAGE CPP #-}
 {-#LANGUAGE DeriveDataTypeable #-}
 {-#LANGUAGE DeriveGeneric #-}
 {-#LANGUAGE MultiParamTypeClasses #-}
@@ -20,7 +21,9 @@ module Twilio.Message.Media
 import Control.Monad
 import Data.Aeson
 import Data.Data
+#if __GLASGOW_HASKELL__ <= 802
 import Data.Monoid
+#endif
 import Data.Text (Text)
 import Data.Time.Clock
 import GHC.Generics

--- a/src/Twilio/Message/MediaList.hs
+++ b/src/Twilio/Message/MediaList.hs
@@ -1,3 +1,4 @@
+{-#LANGUAGE CPP #-}
 {-#LANGUAGE DeriveDataTypeable #-}
 {-#LANGUAGE DeriveGeneric #-}
 {-#LANGUAGE MultiParamTypeClasses #-}
@@ -21,7 +22,9 @@ import Control.Applicative
 import Data.Aeson
 import Data.Data
 import Data.Maybe
+#if __GLASGOW_HASKELL__ <= 802
 import Data.Monoid
+#endif
 import GHC.Generics
 
 import Twilio.Internal.Request

--- a/src/Twilio/OutgoingCallerID.hs
+++ b/src/Twilio/OutgoingCallerID.hs
@@ -1,3 +1,4 @@
+{-#LANGUAGE CPP #-}
 {-#LANGUAGE MultiParamTypeClasses #-}
 {-#LANGUAGE OverloadedStrings #-}
 {-#LANGUAGE ViewPatterns #-}
@@ -19,7 +20,9 @@ module Twilio.OutgoingCallerID
 import Control.Monad
 import Control.Monad.Catch
 import Data.Aeson
+#if __GLASGOW_HASKELL__ <= 802
 import Data.Monoid
+#endif
 import Data.Text (Text)
 import Data.Time.Clock
 import Network.URI

--- a/src/Twilio/Queue.hs
+++ b/src/Twilio/Queue.hs
@@ -1,3 +1,4 @@
+{-#LANGUAGE CPP #-}
 {-#LANGUAGE DeriveDataTypeable #-}
 {-#LANGUAGE DeriveGeneric #-}
 {-#LANGUAGE MultiParamTypeClasses #-}
@@ -22,7 +23,9 @@ import Control.Monad
 import Control.Monad.Catch
 import Data.Aeson
 import Data.Data
+#if __GLASGOW_HASKELL__ <= 802
 import Data.Monoid
+#endif
 import Data.Text (Text)
 import Data.Time.Clock
 import GHC.Generics

--- a/src/Twilio/Queue/Member.hs
+++ b/src/Twilio/Queue/Member.hs
@@ -1,3 +1,4 @@
+{-#LANGUAGE CPP #-}
 {-#LANGUAGE DeriveDataTypeable #-}
 {-#LANGUAGE DeriveGeneric #-}
 {-#LANGUAGE MultiParamTypeClasses #-}
@@ -19,7 +20,9 @@ module Twilio.Queue.Member
 import Control.Monad
 import Data.Aeson
 import Data.Data
+#if __GLASGOW_HASKELL__ <= 802
 import Data.Monoid
+#endif
 import Data.Time.Clock
 import GHC.Generics
 import Network.URI

--- a/src/Twilio/Queue/Members.hs
+++ b/src/Twilio/Queue/Members.hs
@@ -1,3 +1,4 @@
+{-#LANGUAGE CPP #-}
 {-#LANGUAGE DeriveDataTypeable #-}
 {-#LANGUAGE DeriveGeneric #-}
 {-#LANGUAGE MultiParamTypeClasses #-}
@@ -20,7 +21,9 @@ import Control.Applicative
 import Data.Aeson
 import Data.Data
 import Data.Maybe
+#if __GLASGOW_HASKELL__ <= 802
 import Data.Monoid
+#endif
 import GHC.Generics
 
 import Twilio.Queue.Member

--- a/src/Twilio/Recording.hs
+++ b/src/Twilio/Recording.hs
@@ -1,3 +1,4 @@
+{-#LANGUAGE CPP #-}
 {-#LANGUAGE MultiParamTypeClasses #-}
 {-#LANGUAGE OverloadedStrings #-}
 {-#LANGUAGE ViewPatterns #-}
@@ -20,7 +21,9 @@ import Control.Error.Safe
 import Control.Monad
 import Control.Monad.Catch
 import Data.Aeson
+#if __GLASGOW_HASKELL__ <= 802
 import Data.Monoid
+#endif
 import Data.Time.Clock
 import Network.URI
 

--- a/src/Twilio/ShortCode.hs
+++ b/src/Twilio/ShortCode.hs
@@ -1,3 +1,4 @@
+{-#LANGUAGE CPP #-}
 {-#LANGUAGE MultiParamTypeClasses #-}
 {-#LANGUAGE OverloadedStrings #-}
 {-#LANGUAGE ViewPatterns #-}
@@ -18,7 +19,9 @@ module Twilio.ShortCode
 import Control.Monad
 import Control.Monad.Catch
 import Data.Aeson
+#if __GLASGOW_HASKELL__ <= 802
 import Data.Monoid
+#endif
 import Data.Text (Text)
 import Data.Time.Clock
 import Network.URI

--- a/src/Twilio/Transcription.hs
+++ b/src/Twilio/Transcription.hs
@@ -1,3 +1,4 @@
+{-#LANGUAGE CPP #-}
 {-#LANGUAGE MultiParamTypeClasses #-}
 {-#LANGUAGE OverloadedStrings #-}
 {-#LANGUAGE ViewPatterns #-}
@@ -22,7 +23,9 @@ import Control.Error.Safe
 import Control.Monad
 import Control.Monad.Catch
 import Data.Aeson
+#if __GLASGOW_HASKELL__ <= 802
 import Data.Monoid
+#endif
 import Data.Text (Text)
 import Data.Time.Clock
 import Network.URI

--- a/src/Twilio/Types.hs
+++ b/src/Twilio/Types.hs
@@ -34,7 +34,9 @@ import Control.Monad
 import Control.Monad.Reader.Class
 import Data.Aeson
 import qualified Data.ByteString.Char8 as C
+#if __GLASGOW_HASKELL__ <= 802
 import Data.Monoid
+#endif
 import Data.Text (Text)
 import qualified Data.Text as T
 #if MIN_VERSION_http_client(0,5,0)

--- a/src/Twilio/UsageTrigger.hs
+++ b/src/Twilio/UsageTrigger.hs
@@ -1,3 +1,4 @@
+{-#LANGUAGE CPP #-}
 {-#LANGUAGE MultiParamTypeClasses #-}
 {-#LANGUAGE OverloadedStrings #-}
 {-#LANGUAGE ViewPatterns #-}
@@ -18,7 +19,9 @@ module Twilio.UsageTrigger
 import Control.Monad
 import Control.Monad.Catch
 import Data.Aeson
+#if __GLASGOW_HASKELL__ <= 802
 import Data.Monoid
+#endif
 import Data.Text (Text)
 import Data.Time.Clock
 import Network.URI

--- a/twilio.cabal
+++ b/twilio.cabal
@@ -1,5 +1,5 @@
 name:                twilio
-version:             0.3.0.0
+version:             0.3.0.1
 synopsis:            Twilio REST API library for Haskell
 description:         This package exports bindings to Twilio's REST API (<https://www.twilio.com/docs/api/rest>). While we would like to have a complete binding to Twilio's REST API, this package is being developed on demand. If you need something that has not been implemented yet, please send a pull request or file an issue on GitHub (<https://github.com/markandrus/twilio-haskell>).
 homepage:            https://github.com/markandrus/twilio-haskell
@@ -12,7 +12,7 @@ build-type:          Simple
 cabal-version:       >=1.8
 -- NOTE(mroberts): See https://github.com/markandrus/twilio-haskell/issues/44
 -- tested-with:         GHC == 7.8.4, GHC == 7.10.1, GHC == 7.10.2, GHC == 8.0.1
-tested-with:         GHC == 7.10.1, GHC == 7.10.2, GHC == 8.0.1, GHC == 8.0.2
+tested-with:         GHC == 7.10.1, GHC == 7.10.2, GHC == 8.0.1, GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.4, GHC == 8.6.5
 
 source-repository head
   type: git
@@ -88,7 +88,7 @@ library
                        base ==4.*,
                        binary >=0.7,
                        bytestring ==0.10.*,
-                       containers ==0.5.*,
+                       containers >=0.5,
                        deepseq >=1,
                        errors >=1,
                        exceptions ==0.*,


### PR DESCRIPTION
- Added CPP pragmas around Data.Monoid imports
- Removed containers upper bound
- Added a cabal.project for cabal 2.x
- Added a convenience nix shell.nix
- Bumped version
- Updated travis ci with new compiler version support

This supersedes PR #66 as it maintains backwards compatibility.