### PR TITLE
Add new version with support of aeson-2.0 and ghc-9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,14 @@ matrix:
       compiler: ": #GHC 8.0.1"
       addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.1], sources: [hvr-ghc]}}
 
+    - env: BUILD=cabal CABALVER=3.6.2 GHCVER=9.0.2
+      compiler: ": #GHC 9.0.2"
+      addons: {apt: {packages: [cabal-install-3.6.2.0,ghc-9.0.2], sources: [hvr-ghc]}}
+
+    - env: BUILD=cabal CABALVER=3.6.2 GHCVER=9.2.4
+      compiler: ": #GHC 9.2.4"
+      addons: {apt: {packages: [cabal-install-3.6.2.0,ghc-9.2.4], sources: [hvr-ghc]}}
+
     # NOTE(mroberts): I've borrowed this from Yesod's .travis.yml:
     #
     #     https://github.com/yesodweb/yesod/blob/master/.travis.yml
@@ -74,6 +82,10 @@ matrix:
 
     - env: BUILD=stack ARGS="--resolver lts-11"
       compiler: ": #stack 8.2.2"
+      addons: {apt: {packages: [libgmp-dev]}}
+
+    - env: BUILD=stack ARGS="--resolver lts-19"
+      compiler: ": #stack 9.0.2"
       addons: {apt: {packages: [libgmp-dev]}}
 
 before_install:

--- a/src/Control/Monad/Twilio.hs
+++ b/src/Control/Monad/Twilio.hs
@@ -169,6 +169,6 @@ data TwilioException
   | InvalidAuthToken   !Text
   | InvalidCredentials
   | UnexpectedResponse !(Response LBS.ByteString)
-  deriving (Show, Eq, Typeable)
+  deriving (Show, Typeable)
 
 instance Exception TwilioException

--- a/src/Twilio/Tokens.hs
+++ b/src/Twilio/Tokens.hs
@@ -21,7 +21,7 @@ import Control.Error.Safe
 import Control.Monad
 import Control.Monad.Catch
 import Data.Aeson
-import qualified Data.HashMap.Strict as HashMap
+import qualified Data.Aeson.KeyMap as KeyMap
 import Data.Maybe
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -67,13 +67,13 @@ data IceServer
 
 instance FromJSON IceServer where
   parseJSON (Object map) =
-    let url = HashMap.lookup "url" map >>= valueToText >>= parseAbsoluteURI . T.unpack
+    let url = KeyMap.lookup "url" map >>= valueToText >>= parseAbsoluteURI . T.unpack
     in  case url of
       Nothing   -> mzero
       Just url' -> return . fromMaybe (StunServer url') $ TurnServer
         <$> url
-        <*> (HashMap.lookup "credential" map >>= valueToText)
-        <*> (HashMap.lookup "username"   map >>= valueToText)
+        <*> (KeyMap.lookup "credential" map >>= valueToText)
+        <*> (KeyMap.lookup "username"   map >>= valueToText)
   parseJSON _ = mzero
 
 instance Post0 Token where

--- a/src/Twilio/Tokens.hs
+++ b/src/Twilio/Tokens.hs
@@ -2,6 +2,7 @@
 {-#LANGUAGE MultiParamTypeClasses #-}
 {-#LANGUAGE OverloadedStrings #-}
 {-#LANGUAGE ViewPatterns #-}
+{-# LANGUAGE CPP #-}
 -------------------------------------------------------------------------------
 -- |
 -- Module      :  Twilio.Tokens
@@ -21,13 +22,18 @@ import Control.Error.Safe
 import Control.Monad
 import Control.Monad.Catch
 import Data.Aeson
-import qualified Data.Aeson.KeyMap as KeyMap
 import Data.Maybe
 import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Text.Encoding
 import Data.Time.Clock
 import Network.URI
+
+#if MIN_VERSION_aeson(2,0,0)
+import qualified Data.Aeson.KeyMap as KeyMap
+#else
+import qualified Data.HashMap.Strict as KeyMap
+#endif
 
 import Control.Monad.Twilio
 import Twilio.Types

--- a/src/Twilio/Types/Capability.hs
+++ b/src/Twilio/Types/Capability.hs
@@ -12,10 +12,11 @@ module Twilio.Types.Capability where
 
 import Control.Monad
 import Data.Aeson
-import qualified Data.HashMap.Strict as HashMap
+import Data.Maybe
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.Aeson.Key as Key
 import Data.Set (Set)
 import qualified Data.Set as Set
-import qualified Data.Text as T
 
 type Capabilities = Set Capability
 
@@ -26,12 +27,12 @@ data Capability
   deriving (Bounded, Enum, Eq, Ord, Read, Show)
 
 instance {-# OVERLAPPING #-} FromJSON Capabilities where
-  parseJSON (Object map) 
+  parseJSON (Object map)
     = let map' = fmap (\value -> case value of
                         Bool bool     -> bool
                         _             -> False) map
       in  return $ foldr (\capability set ->
-            if HashMap.lookupDefault False (T.pack $ show capability) map'
+            if fromMaybe False $ KeyMap.lookup (Key.fromString $ show capability) map'
               then Set.insert capability set
               else set
           ) Set.empty [Voice, SMS, MMS]

--- a/src/Twilio/Types/List.hs
+++ b/src/Twilio/Types/List.hs
@@ -3,6 +3,7 @@
 {-#LANGUAGE FunctionalDependencies #-}
 {-#LANGUAGE OverloadedStrings #-}
 {-#LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE CPP #-}
 -------------------------------------------------------------------------------
 -- |
 -- Module      :  Twilio.Types.List
@@ -26,6 +27,12 @@ import Data.Data
 import Debug.Trace (trace)
 import GHC.Generics
 import Network.URI
+
+#if MIN_VERSION_aeson(2,0,0)
+#else
+import Data.Text (Text)
+type Key = Text
+#endif
 
 (<&>) :: Functor f => f a -> (a -> b) -> f b
 (<&>) = flip fmap

--- a/src/Twilio/Types/List.hs
+++ b/src/Twilio/Types/List.hs
@@ -23,7 +23,6 @@ import Control.Monad
 import Data.Aeson
 import Data.Aeson.Types
 import Data.Data
-import Data.Text (Text)
 import Debug.Trace (trace)
 import GHC.Generics
 import Network.URI
@@ -43,14 +42,14 @@ class FromJSON b => List a b | a -> b where
   getList :: a -> [b]
 
   -- | The plural name for the items in the 'List'.
-  getPlural :: Const Text (a, b)
+  getPlural :: Const Key (a, b)
 
   -- | Parse a 'JSON' 'Value' to an instance of the 'List'.
   parseJSONToList :: Value -> Parser a
   parseJSONToList o@(Object v)
       =  unwrap (getListWrapper :: Wrapper (Maybe PagingInformation -> [b] -> a))
      <$> maybePagingInformation
-     <*> (v .: getConst (getPlural :: Const Text (a, b)) :: Parser [b])
+     <*> (v .: getConst (getPlural :: Const Key (a, b)) :: Parser [b])
     where
       maybePagingInformation = case fromJSON o of
         Success pagingInformation -> return $ Just pagingInformation

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-8.20
+resolver: lts-19.25
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/twilio.cabal
+++ b/twilio.cabal
@@ -84,7 +84,7 @@ library
                        Twilio.UsageTrigger,
                        Twilio.UsageTriggers
   hs-source-dirs:      src
-  build-depends:       aeson >=2.0,
+  build-depends:       aeson >= 0.11 && <1.6 || >=2.0 && <2.2,
                        base ==4.*,
                        binary >=0.7,
                        bytestring ==0.11.*,
@@ -102,7 +102,7 @@ library
                        old-locale ==1.0.*,
                        scientific ==0.*,
                        template-haskell >=2,
-                       text ==1.*,
+                       text ==1.* || ==2.0.*,
                        time >=1,
                        transformers >=0.3,
                        unordered-containers ==0.2.*

--- a/twilio.cabal
+++ b/twilio.cabal
@@ -1,5 +1,5 @@
 name:                twilio
-version:             0.3.0.0
+version:             0.4.0.0
 synopsis:            Twilio REST API library for Haskell
 description:         This package exports bindings to Twilio's REST API (<https://www.twilio.com/docs/api/rest>). While we would like to have a complete binding to Twilio's REST API, this package is being developed on demand. If you need something that has not been implemented yet, please send a pull request or file an issue on GitHub (<https://github.com/markandrus/twilio-haskell>).
 homepage:            https://github.com/markandrus/twilio-haskell
@@ -84,11 +84,11 @@ library
                        Twilio.UsageTrigger,
                        Twilio.UsageTriggers
   hs-source-dirs:      src
-  build-depends:       aeson >=0.8 && <0.10 || >=0.11,
+  build-depends:       aeson >=2.0,
                        base ==4.*,
                        binary >=0.7,
-                       bytestring ==0.10.*,
-                       containers ==0.5.*,
+                       bytestring ==0.11.*,
+                       containers ==0.6.*,
                        deepseq >=1,
                        errors >=1,
                        exceptions ==0.*,


### PR DESCRIPTION
Hi!

I'm actively using this library, and we're planning to migrate our project to ghc9.
Since there is no open PR with similar changes, I decided to send mine.

I think there are still some questions needs to be resolved, for example updating of travis.ci configuration, and removal of Eq instance from Network.HTTP.Client.Response.
But overall, I think this version should work fine.

Any suggestions are welcome, and I'll try to fix them asap.